### PR TITLE
Update util.sh

### DIFF
--- a/extensions/util.sh
+++ b/extensions/util.sh
@@ -21,8 +21,8 @@ PARTITION="/dev/disk/azure/scsi1/lun0-part1"
 MOUNTPOINT="/datadisk"
 
 echo "Partitioning the disk."
-echo "n
-g
+echo "g
+n
 p
 1
 


### PR DESCRIPTION
Fixed the order of fdisk commands to work properly.

'g' comes before 'n' in fdisk here.

Confirmed working here on build today 

couchbase@server000000:~$ df -h /datadisk
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdc1       4.0T   67M  3.8T   1% /datadisk


